### PR TITLE
Try that, pun intended

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -296,7 +296,11 @@ try:
             previous_topology_counts = \
                 cls.previous_topology_counts
             if not None is previous_topology_counts:
-                previous_data_name = previous_topology_counts['data'].name
+                try:
+                    previous_data_name = previous_topology_counts['data'].name
+                except Exception:
+                    previous_data_name = None
+                    print('Caught: Stale mesh topology counts, (was probably deleted) - in MeshLint')
             else:
                 previous_data_name = None
             now_name = now_counts['data'].name


### PR DESCRIPTION
Added Try block around the previous topology reference.
If there is a exception it is dealt with by setting the topology to None which is the default condition of the module.