### PR TITLE
Unittest refactor & Test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+---
+### Version 0.1.2 for Blender 4.2 and 4.3
+
+New Features:
+* None. Works with Blender 4.2 and 4.3
+
+Fixes:
+* Refactoring out unittests #10
+  * Separate unittests into new file
+  * Test suite to execute multiple Blender versions.
+
+Known Issues:
+* Incorrect lint selection with multiple objects #7
+* Deselection of Lint-free objects does not happen if all are lint free.
+* Discovered broken for Blender 4.4 & 4.5 - they changed a python API. #9
 
 ---
 ### Version 0.1.1-for-4.2
@@ -7,7 +22,7 @@
 Swtya
 
 New Features: 
-* Behaves as an Extension now.
+* Behaves as an Extension now. Works with Blender 4.2 and 4.3
 
 Fixes:
 * Move from Addon to Extension #6
@@ -20,6 +35,8 @@ Fixes:
 
 Known Issues:
 * Incorrect lint selection with multiple objects #7
+* Deselection of Lint-free objects does not happen if all are lint free.
+* Broken for Blender 4.4 - they changed a python API.
 
 ---
 ### Version 0.1.1-for-4.2-beta

--- a/__init__.py
+++ b/__init__.py
@@ -69,6 +69,8 @@ class MeshLintAnalyzer:
     CHECKS = []
 
     def __init__(self):
+    # def __init__(self, *args, **kwargs):
+        #super().__init__(*args, **kwargs)      # For blender 4.4 onwards
         ensure_edit_mode()
         self.obj = bpy.context.active_object
         self.b = bmesh.from_edit_mesh(self.obj.data)
@@ -419,9 +421,11 @@ class MeshLintVitalizer(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        """Blender Gatekeeper"""
         return has_active_mesh(context) and is_edit_mode()
 
     def execute(self, context):
+        """Main function of the Blender operator, run after the gatekeeper"""
         if MeshLintVitalizer.is_live:
             bpy.app.handlers.depsgraph_update_post.remove(meshlint_gbl_continuous_check)
             MeshLintVitalizer.is_live = False
@@ -445,6 +449,8 @@ def activate(obj):
 class MeshLintObjectLooper:
     """Routines for examining the scene objects"""
     def __init__(self):
+    # def __init__(self, *args, **kwargs):
+        # super().__init__(*args, **kwargs)         # For blender 4.4 onwards
         self.original_active = bpy.context.active_object
         self.troubled_meshes = []
 
@@ -461,7 +467,9 @@ class MeshLintObjectLooper:
                 indices = lint[elemtype]
                 analyzer.select_indices(elemtype, indices)
         # print('selected all the issues')
-        bpy.context.area.tag_redraw()
+        for area in bpy.context.screen.areas:
+            if area.type == 'VIEW_3D':      # Headless Blender does not have a VIEW_3D for a redraw event.
+                area.tag_redraw()           # 'NoneType' object has no attribute 'tag_redraw' when headless
         return analyzer.found_zero_problems()
 
     def examine_all_selected_meshes(self):
@@ -482,7 +490,9 @@ class MeshLintObjectLooper:
                 break
         if self.troubled_meshes:
             MeshLintObjectDeselector.handle_troubled_meshes(self)
-        bpy.context.area.tag_redraw()
+        for area in bpy.context.screen.areas:
+            if area.type == 'VIEW_3D':      # Headless Blender does not have a VIEW_3D for a redraw event.
+                area.tag_redraw()           # 'NoneType' object has no attribute 'tag_redraw' when headless
 
     # def select_none(self):
         # bpy.ops.mesh.select_all(action='DESELECT')
@@ -496,9 +506,11 @@ class MeshLintSelector(MeshLintObjectLooper, bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        """Blender Gatekeeper"""
         return has_active_mesh(context)
 
     def execute(self, context):
+        """Main function of the Blender operator, run after the gatekeeper"""
         original_mode = bpy.context.mode
         if is_edit_mode():
             self.examine_active_object()
@@ -525,10 +537,12 @@ class MeshLintObjectDeselector(MeshLintObjectLooper, bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
+        """Blender Gatekeeper"""
         selected_meshes = [o for o in context.selected_objects if o.type == 'MESH']
         return 1 < len(selected_meshes) and not is_edit_mode()
 
     def execute(self, context):
+        """Main function of the Blender operator, run after the gatekeeper"""
         self.examine_all_selected_meshes()
         return {'FINISHED'}
 
@@ -679,281 +693,26 @@ def depluralize(**args):
         return args['string'].rstrip('s')
     return args['string']
 
-# Next section of the file is unittest
-# Classes and registration is right at the end as required by Blender.
 
+# Next section of the file is unittest
 try:        # (Back at 2.79) Why does it work for some Blender's but not others?
     import unittest
     import warnings
 
-    class TestControl(unittest.TestCase):
-        """ Test the functions in the main block:
-            # has_unapplied_scale
-            # is_bad_name   """
-        def test_scale_application(self):
-            """Check for unapplied scale """
-            for bad in [[0, 0, 0], [1, 2, 3], [1, 1, 1.1]]:
-                self.assertEqual(
-                    True, MESH_PT_MeshLintControl.has_unapplied_scale(bad),
-                    "Unapplied scale: %s" % bad)
-            self.assertEqual(
-                False, MESH_PT_MeshLintControl.has_unapplied_scale([1, 1, 1]),
-                "Applied scale (1,1,1)")
-
-        def test_bad_names(self):
-            """Check a couple of good & bad names likely to be in the scene"""
-            for bad in ['Cube', 'Cube.001', 'Sphere.123']:
-                self.assertEqual(
-                    True, MESH_PT_MeshLintControl.is_bad_name(bad),
-                    f"Bad name: {bad}")
-            for aok in ['Whatever', 'NumbersOkToo.001']:
-                self.assertEqual(
-                    False, MESH_PT_MeshLintControl.is_bad_name(aok),
-                    f"OK name: {aok}")
-
-    class TestUtilities(unittest.TestCase):
-        """ Test class for utilities:
-                # ensure_edit_mode, is_edit_mode
-                # ensure_not_edit_mode, is_edit_mode
-                # depluralize  """
-        def test_is_edit_mode(self):
-            """Check flipping in and out of edit mode"""
-            ensure_edit_mode()
-            self.assertEqual(True, is_edit_mode(),
-                "Ensures edit mode then checks if in edit mode")
-            ensure_not_edit_mode()
-            self.assertEqual(False, is_edit_mode(),
-                "Ensures not edit mode then checks if not edit mode")
-
-        def test_depluralize(self):
-            """The depluralize attempts to remove a lower case 's'
-            only if the count arg is exactly 1. This is obviously limited in generalist capabilities.
-            I'm messing around here but "Tris" does end up at "Tri" currently."""
-            self.assertEqual('foo',
-                depluralize(count=1, string='foos'))
-            self.assertEqual('foos',
-                depluralize(count=2, string='foos'))
-            self.assertNotEqual('FOO',
-                depluralize(count=1, string='FOOS'))
-            self.assertNotEqual('fox',
-                depluralize(count=1, string='foxes'),"Singular of Foxes is Foxe!")
-            self.assertNotEqual('Blueberry',
-                depluralize(count=1, string='Blueberries'),"Singular of Blueberries is Blueberrie")
-            self.assertEqual('sheep',
-                depluralize(count=1, string='sheep'),"Singular of Sheep is Sheep")
-
-    class TestAnalysis(unittest.TestCase):
-        """Checks the making of the dictionary."""
-        def test_make_labels_dict(self):
-            """Checks that the format of the labels in the dictionary is good"""
-            self.assertEqual(
-                {
-                    'Label One': {
-                        'edges': [1, 2], 'verts': [], 'faces': []},
-                    'Label Two': {
-                        'edges': [], 'verts': [5], 'faces': [3]}
-                },
-                MeshLintContinuousChecker.make_labels_dict(
-                    [
-                        {'lint': {'label': 'Label One'},
-                            'edges': [1, 2], 'verts': [], 'faces': []},
-                        {'lint': {'label': 'Label Two'},
-                            'edges': [], 'verts': [5], 'faces': [3]}
-                    ]),
-                'Conversion of incoming analysis into label-keyed dict')
-            self.assertEqual({},
-                MeshLintContinuousChecker.make_labels_dict(None),
-                'Handles "None" OK.')
-
-        def test_comparison(self):
-            """ Test group to check the diff_analyses block of code
-            1) None - None = None            # constant labels
-            2) None - thing = thing          # constant labels
-            3) a(set) - b(set) = (a-b)(set)  # constant labels
-            4) A(B) - C(D) = (A-C)(B-D)      # labels and data both change """
-            self.assertEqual(
-                None,
-                MeshLintContinuousChecker.diff_analyses(
-                    MeshLintAnalyzer.none_analysis(),
-                    MeshLintAnalyzer.none_analysis()),
-                'Two none_analysis()s')
-            self.assertEqual(
-                'Found Tris: 4 verts',
-                MeshLintContinuousChecker.diff_analyses(
-                    None,
-                    [
-                        {
-                            'lint': {'label': 'Tris'},
-                            'verts': [1, 2, 3, 4],
-                            'edges': [],
-                            'faces': [],
-                        },
-                    ]),
-                'When there was no previous analysis')
-            self.assertEqual(
-                'Found Tris: 2 edges, ' +
-                'Nonmanifold Elements: 4 verts, 2 faces',
-                MeshLintContinuousChecker.diff_analyses(
-                    [
-                        {'lint': {'label': 'Tris'},
-                         'verts': [], 'edges': [1, 4], 'faces': [], },
-                        {'lint': {'label': 'CheckB'},
-                         'verts': [], 'edges': [2, 3], 'faces': [], },
-                        {'lint': {'label': 'Nonmanifold Elements'},
-                         'verts': [], 'edges': [], 'faces': [2, 3], },
-                    ],
-                    [
-                        {'lint': {'label': 'Tris'},
-                         'verts': [], 'edges': [1, 4, 5, 6], 'faces': [], },
-                        {'lint': {'label': 'CheckB'},
-                         'verts': [], 'edges': [2, 3], 'faces': [], },
-                        {'lint': {'label': 'Nonmanifold Elements'},
-                         'verts': [1, 2, 3, 4], 'edges': [], 'faces': [1, 2, 3, 5], },
-                    ]),
-                'Complex comparison of analyses')
-            self.assertEqual(
-                'Found Tris: 2 verts, Ngons: 2 faces, ' +
-                'Nonmanifold Elements: 2 edges',
-                MeshLintContinuousChecker.diff_analyses(
-                    [
-                        {'lint': {'label': '6+-edge Poles'},
-                         'verts': [], 'edges': [2, 3], 'faces': [], },
-                        {'lint': {'label': 'Nonmanifold Elements'},
-                         'verts': [], 'edges': [2, 3], 'faces': [], },
-                    ],
-                    [
-                        {'lint': {'label': 'Tris'},
-                         'verts': [55, 56], 'edges': [], 'faces': [], },
-                        {'lint': {'label': 'Ngons'},
-                         'verts': [], 'edges': [], 'faces': [5, 6], },
-                        {'lint': {'label': 'Nonmanifold Elements'},
-                         'verts': [], 'edges': [2, 3, 4, 5], 'faces': [], },
-                    ]),
-                'User picked a different set of checks since last run.')
-
-    class MockBlenderObject:
-        """A very simple object on which to test some properties"""
-        def __init__(self, name, scale=Vector([1, 1, 1])):
-            self.name = name
-            self.scale = scale
-
-    class TestUI(unittest.TestCase):
-        """This group of tests cover the UI parts of the Extension"""
-        def test_complaints(self):
-            """Tests for the text manipulation of the GUI
-                # using build_object_criticisms
-            """
-            fff = MESH_PT_MeshLintControl.build_object_criticisms
-            self.assertEqual([], fff([], 0), 'Nothing selected')
-            self.assertEqual([],
-                fff([MockBlenderObject('lsmft')], 0),
-                'Ok name')
-            self.assertEqual(['...but "Cube" is not a great name.'],
-                fff([MockBlenderObject('Cube')], 0),
-                'Bad name, otherwise problem-free.')
-            self.assertEqual([],
-                fff([MockBlenderObject('Hassenfrass')], 12),
-                'Good name, but with problems.')
-            self.assertEqual(['...and also "Cube" is not a great name.'],
-                fff([MockBlenderObject('Cube')], 23),
-                'Bad name, and problems, too.')
-            self.assertEqual(['...but "Sphere" is not a great name.',
-                                   '...and also "Cube" is not a great name.'],
-                fff([MockBlenderObject('Sphere'),
-                            MockBlenderObject('Cube')], 0),'Two bad names.')
-            scaled = MockBlenderObject('Solartech', scale=Vector([.2, 2, 1]))
-            self.assertEqual(['...but "Solartech" has an unapplied scale.'],
-                fff([scaled], 0),'Only problem is unapplied scale.')
-
-    class QuietOnSuccessTestResult(unittest.TextTestResult):
-        """ This is used for overriding results print out from the unittest test runner. """
-        def startTest(self, test):
-            """ The pass in here prevents terminal printout from unittest """
-            # pass # [unnecessary-pass]
-
-        def addSuccess(self, test):
-            """ The pass in here prevents terminal printout from unittest """
-            # pass # [unnecessary-pass]
-
-    class QuietTestRunner(unittest.TextTestRunner):
-        """ The Quiet Test Runner runs tests very quietly, it only prints out to the terminal if there
-         are fails. On a fail, the output text incorrectly reports the number of tests run!"""
-        resultclass = QuietOnSuccessTestResult
-
-        # Ugh. I really shouldn't have to include this much code, but they left it so unrefactored
-        # I don't know what else to do. My other option is to override the stream and substitute
-        # out the success case, but that's a mess, too. - rking
-        def run(self, test):
-            """Run the suite of test, quietly."""
-            debug_print = True  # Bool: Suppressing debug printing test verification
-
-            if debug_print:
-                print("MeshLint: starting QuietTestRunner.run")
-            result = self._makeResult()
-            unittest.registerResult(result)
-            result.failfast = self.failfast
-            result.buffer = self.buffer
-            with warnings.catch_warnings():
-                if self.warnings:
-                    # if self.warnings is set, use it to filter all the warnings
-                    warnings.simplefilter(self.warnings)
-                    # if the filter is 'default' or 'always', special-case the warnings from the deprecated
-                    # unittest methods to show them no more than once per module, because they can be fairly
-                    # noisy.  The -Wd and -Wa flags can be used to bypass this only when self.warnings is None.
-                    if self.warnings in ['default', 'always']:
-                        warnings.filterwarnings('module',
-                                                category=DeprecationWarning,
-                                                message=r'Please use assert\w+ instead.')
-                startTime = time.time()
-                startTestRun = getattr(result, 'startTestRun', None)
-                if getattr(result, 'startTestRun', None) is not None:
-                    startTestRun()
-                try:
-                    test(result)
-                finally:
-                    stopTestRun = getattr(result, 'stopTestRun', None)
-                    if stopTestRun is not None:
-                        stopTestRun()
-                stopTime = time.time()
-            result.printErrors()
-
-            expectedFails = unexpectedSuccesses = skipped = 0
-            try:
-                results = map(len, (result.expectedFailures,
-                                    result.unexpectedSuccesses,
-                                    result.skipped))
-            except AttributeError:
-                pass
-            else:
-                expectedFails, unexpectedSuccesses, skipped = results
-
-            infos = []
-            if not result.wasSuccessful():
-                self.stream.write("FAILED")
-                failed, errored = len(result.failures), len(result.errors)
-                if failed:
-                    infos.append(f"failures={failed:d}")
-                if errored:
-                    infos.append(f"errors={errored:d}")
-            if skipped:
-                infos.append(f"skipped={skipped:d}")
-            if expectedFails:
-                infos.append(f"expected failures={expectedFails:d}")
-            if unexpectedSuccesses:
-                infos.append(f"unexpected successes={unexpectedSuccesses:d}")
-            if debug_print:
-                print(f"\nQuietTestRunner Time Taken: {stopTime - startTime} seconds")
-                print(f"---Result Start---\n{result}\n---Result End---")
-                print(f"---infos Start---\n{infos}\n---infos End---")
-            return result
-
     if __name__ == '__main__':
-        BE_QUIET = False
+        BE_QUIET = True
         """ How to run the unittest using Blender, Linux example, from a terminal:
           '/home/<<path=to-blender>>/blender-4.2.0-linux-x64/blender' --background --python '/home/<<path-to-this-file>>/__init__.py'  -- --verbose
         There are two styles, hence the two different unittest.main calls; depends on your workflow. """
+        import os
+        import sys
+        cwd = os.path.dirname(os.path.abspath(__file__))  # Put this folder on the Blender system path
+        sys.path.append(cwd)  # So that relative imports work
+        # print(f'System path is: {sys.path}')  # Debug print should show path of this file included.
+        from unittest_classes import *
+
         if BE_QUIET:
-            # This will print nothing if it passes, but did it run...
+            # This will print nothing if it passes, but did it run honest...
             unittest.main(
                 testRunner=QuietTestRunner,
                 argv=['dummy'],
@@ -962,7 +721,6 @@ try:        # (Back at 2.79) Why does it work for some Blender's but not others?
                 warnings='always')
         else:
             print('   MeshLint: Hello from unittester')
-            import sys
             sys.argv = [__file__] + (sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else [])
             print(sys.argv)
             unittest.main(exit=False)
@@ -973,6 +731,8 @@ except ImportError:
         No harm, but it is odd. If you want to help raise an issue on GitHub
         describing your system, it may be possible to track down this condition.""")
 
+
+# Addon classes and registration are right at the end as required by Blender.
 classes = (
     MESH_PT_MeshLintControl,
     MeshLintObjectDeselector,

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -2,11 +2,11 @@ schema_version = "1.0.0"
 
 # Manifest file for MeshLint following documentation at, 
 # https://docs.blender.org/manual/en/latest/advanced/extensions/getting_started.html
-# The id is case sensitive with directory name!
+# The id is case-sensitive with directory name!
 
 id = "MeshLint"
 name = "MeshLint"
-version = "0.1.1"
+version = "0.1.2"
 tagline = "MeshLint is like spell-checking for your Meshes"
 # "description": "Check objects for: Tris / Ngons / Nonmanifoldness / etc"
 # "location": "Object Data properties > MeshLint"
@@ -29,7 +29,9 @@ copyright = ["2012 rking"]
 paths_exclude_pattern = [
   "__pycache__/",
   "testblends",
+  "tests",
   "/.*/",
   "/.*",
   "/*.zip",
+  "/*.blend*",
 ]

--- a/tests/check_installed.py
+++ b/tests/check_installed.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 Swtya
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Called by main.py to check if the extension is available for the version of Blender.
+"""
+
+import sys
+import traceback
+
+import addon_utils
+import bmesh
+import bpy
+
+EXTENSION_NAME = "MeshLint"     # Case matters
+MIN_VERSION = (0,1,2)
+
+
+def test_loaded() -> None:
+    """
+    A corrupted py file would still appear with a version but not be in the loaded state.
+    When all is well addon_utils.check('bl_ext.blender_org.MeshLint') should return (True, True).
+    :return: None
+    """
+    for ext_id in addon_utils.modules().mapping:
+        if ext_id.split(".")[-1] == EXTENSION_NAME:
+            (loaded_default, loaded_state) = addon_utils.check(ext_id)
+            assert loaded_default, f"Extension {EXTENSION_NAME} not loaded by default."
+            assert loaded_state, f"Extension {EXTENSION_NAME} not currently loaded."
+            break       # Once the extension has been found we can stop looking.
+
+
+def test_version() -> None:
+    """
+    Checks the version number of the extension.
+    :return: None
+    """
+    prefs = bpy.context.preferences
+    used_ext = {ext.module for ext in prefs.addons}
+    addons = [(mod, addon_utils.module_bl_info(mod))
+              for mod in addon_utils.modules(refresh=False)]
+    for mod, info in addons:
+        modname = mod.__name__
+        if modname in used_ext:
+            if modname.split(".")[-1] == EXTENSION_NAME:
+                version = info['version'] if info['version'] else (0,0,0)
+                # print(modname, version)
+                # Version must be >= 0.1.0 otherwise it's too old
+                assert (version[0] > MIN_VERSION[0] or
+                        (version[0]==MIN_VERSION[0] and version[1]>MIN_VERSION[1]) or
+                        (version[0]==MIN_VERSION[0] and version[1]==MIN_VERSION[1] and version[2]>=MIN_VERSION[2])),\
+                    f"Extension Version too old, {version}. Minimum is {MIN_VERSION}."
+
+
+def main() -> None:
+    """
+    Checks to see if the extension is listed as an addon.
+    If a match is found then further tests are conducted for the version and loading status.
+    :return:
+    """
+    for ext_id in addon_utils.modules().mapping:
+        if ext_id.split(".")[-1] == EXTENSION_NAME:
+            assert addon_utils.check_extension(ext_id)
+            #print("Found the extension")
+            break
+    else:
+        assert False, f"No Extension with the name {EXTENSION_NAME} was found."
+
+    for name, test in globals().items():
+        if name.startswith("test"):
+            test()
+
+
+try:
+    main()
+except:
+    traceback.print_exc()
+    sys.exit(1)

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 Swtya
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Welcome to the Mesh Lint regression test suite.
+This tool will run a range of tests on the MeshLint using multiple versions of Blender.
+    Warning: If there is a parsing error in the test_xxxx.py file then Blender does not return an error which
+             results in this test runner saying that it passes!
+    How to run this:
+        From the terminal / cmd prompt call main() with the system installed python.
+        e.g. @AMD5600g:~/github-git/meshlint-update-to-4.2/tests$ python3 main.py
+        From within PyCharm the main.py can simply be "Run".
+    Output should look like this:
+        BEGIN
+        blender-4.2.0-linux-x64 check_installed PASSED
+        blender-4.2.0-linux-x64 test_default PASSED
+          etc.
+        END
+"""
+
+import subprocess
+from pathlib import Path
+
+TEST_VERSIONS = {
+    "4.2.0",
+    "4.3.2",
+    "4.4.0",
+    "4.5.0",
+}
+
+# Color codes
+RED = "\033[91m"
+GREEN = "\033[92m"
+INVERSE = "\033[7m"
+RESET = "\033[0m"
+
+def main(app_location_path) -> None:
+    """
+    :param app_location_path: optional path to find installed versions of blender on the system.
+    :return: None, just a print output to the terminal.
+    """
+
+    if app_location_path:
+        app_location = Path(app_location_path)
+    elif Path().home().joinpath('Blender_apps').is_dir():
+        app_location = Path().home().joinpath('Blender_apps')
+    else:
+        app_location = Path().home()
+    # print(app_location)
+
+    ## Build an array of the directories which contain Blender that are included in the set we want to test with.
+    blender_apps = []
+    for entry in app_location.iterdir():
+        if entry.is_dir() and entry.name.startswith("blender") and entry.name.split("-")[1] in TEST_VERSIONS:
+            blender_apps.append(entry)
+    # print(blender_apps)
+
+    ## Find the test files to run, allows for expansible set.
+    tests = []
+    for entry in Path(__file__).parent.iterdir():
+        if entry.is_file() and entry.suffix == ".py" and entry.name.startswith("test"):
+            tests.append(entry)
+    print(tests)
+
+    print(INVERSE + "BEGIN" + RESET)
+
+    ## Call headless Blender versions, checking for Addon installation before calling tests.
+    for blender in blender_apps:
+        check_install = Path(__file__).with_name('check_installed.py')
+        cmd = [blender / "blender", "-b", "-P", check_install]
+        proc = subprocess.run(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, text = True)
+        # print(proc.stdout)      # Debug printing
+        if proc.returncode:
+            print(f"{RED + blender.name} {check_install.stem} {INVERSE}FAILED{RESET}")
+            # print(proc.stderr.decode().strip())
+            print(proc.stderr)
+            continue   # skip the rest of the for loop for this Blender version
+        else:
+            print(f"{blender.name} {check_install.stem} {GREEN + INVERSE}PASSED{RESET}")
+
+        for test in tests:
+            #cmd = [blender / "blender.exe", "-b", "-P", test]      # Windows ?
+            cmd = [blender / "blender", "-b", "-P", test]           # Works on Linux for extracted tar.xz.
+            proc = subprocess.run(cmd, capture_output=True)
+            # print(proc.stdout)  # Debug printing
+            if proc.returncode:
+                print(f"{RED + blender.name} {test.stem} {INVERSE}FAILED{RESET}")
+                print(proc.stderr.decode().strip())
+                continue    # Continue statement so it runs all test files
+            else:
+                print(f"{blender.name} {test.stem} {GREEN + INVERSE}PASSED{RESET}")
+
+    print(INVERSE + "END" + RESET)
+
+
+print(f"Welcome to the test runner.")
+print(f"Please enter the path to your Blender installs or press return to accept the default.")
+#main(input())      # Allow user to specify a path to folder of their Blender applications.
+main([])            # Straight run from file run in PyCharm.

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 Swtya
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+This is a test runner file that is called from main.py in the same directory.
+In here there are specific regression tests for the Addon / Extension.
+main.py has already checked, for the version of Blender this is called headless against, the extension
+is already installed and enabled.
+"""
+
+import sys
+import traceback
+
+import bmesh
+import bpy
+
+# Relative imports are taken from the Blender.EXE file location, so add file location to path.
+import os
+if bpy.context.space_data is None:        # Check if script is opened in Blender program.
+    cwd = os.path.dirname(os.path.abspath(__file__))
+else:
+    cwd = os.path.dirname(bpy.context.space_data.text.filepath)
+sys.path.append(cwd)
+from utils import *
+
+
+def test_add_cube() -> None:
+    """
+    Adds the default cube into the scene. Assert check on the number of vertices.
+    :return: None
+    """
+    bpy.ops.mesh.primitive_cube_add()
+    bpy.ops.meshlint.select()
+    obj = bpy.context.active_object
+    vert_count = count_verts(obj)
+    assert vert_count == 8, f"Vert count was, {vert_count}, should have been 8."
+    assert count_interior_faces(obj) == 0, f"There was some interior faces."
+
+    delete_active_object()
+
+
+def main() -> None:
+    """
+    Main function to collect all the test definition functions above and execute them.
+    :return: None
+    """
+    for name, test in globals().items():
+        if name.startswith("test"):
+            test()
+
+
+try:
+    main()
+    # assert 0      # Uncomment this, during development, to verify that the file did really run to completion.
+except:
+    panic_save_temp_file(f'tester_crash_{os.path.splitext(os.path.basename(__file__))[0]}.blend')
+    traceback.print_exc()
+    sys.exit(1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 Swtya
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+This file that is called from test_xxxx.py in the same directory.
+In here are a collection of utilities called common to several tests functions
+part of the Addon / Extension testing framework.
+"""
+
+import bmesh
+import bpy
+
+
+def delete_active_object() -> None:
+    """
+    Deletes ths active object after switching to object mode.
+    :return: None
+    """
+    bpy.ops.object.mode_set(mode='OBJECT')
+    bpy.ops.object.delete()
+
+
+def count_interior_faces(obj):
+    """
+    :param obj: The object to test for interior faces.
+    :return: The number of interior faces
+    """
+    bpy.ops.object.mode_set(mode='EDIT')
+    bpy.ops.mesh.select_all(action='DESELECT')
+    bpy.ops.mesh.select_interior_faces()
+    b = bmesh.from_edit_mesh(obj.data)
+    # selected_verts = [vert for vert in b.verts if vert.select]
+    # selected_edges = [edge for edge in b.edges if edge.select]
+    selected_faces = [face for face in b.faces if face.select]
+    return len(selected_faces)
+
+
+def count_verts(obj):
+    """
+    :param obj: The object to return the vertex count of.
+    :return: Total number of verts
+    """
+    bpy.ops.object.mode_set(mode='EDIT')
+    b = bmesh.from_edit_mesh(obj.data)
+    return len(b.verts)
+
+
+def panic_save_temp_file(file_name='utils_tester_crash.blend') -> None:
+    # Saves the scene out to a blend file for later observation.
+    import os
+    location = os.path.abspath(file_name)
+    print(f"* Location of output file --> {location} ")
+    bpy.ops.wm.save_as_mainfile(filepath=location)

--- a/unittest_classes.py
+++ b/unittest_classes.py
@@ -1,0 +1,278 @@
+# This file contains the classes for the unit test machine
+
+from __init__ import *
+
+
+class QuietOnSuccessTestResult(unittest.TextTestResult):
+    """ This is used for overriding results print out from the unittest test runner. """
+
+    def startTest(self, test):
+        """ The pass in here prevents terminal printout from unittest """
+        # pass # [unnecessary-pass]
+
+    def addSuccess(self, test):
+        """ The pass in here prevents terminal printout from unittest """
+        # pass # [unnecessary-pass]
+
+
+class QuietTestRunner(unittest.TextTestRunner):
+    """ The Quiet Test Runner runs tests very quietly, it only prints out to the terminal if there
+     are fails. On a fail, the output text incorrectly reports the number of tests run!"""
+    resultclass = QuietOnSuccessTestResult
+
+    # Ugh. I really shouldn't have to include this much code, but they left it so unrefactored
+    # I don't know what else to do. My other option is to override the stream and substitute
+    # out the success case, but that's a mess, too. - rking
+    def run(self, test):
+        """Run the suite of test, quietly."""
+        debug_print = False  # Bool: Suppressing debug printing test verification
+
+        if debug_print:
+            print("MeshLint: starting QuietTestRunner.run")
+        result = self._makeResult()
+        unittest.registerResult(result)
+        result.failfast = self.failfast
+        result.buffer = self.buffer
+        with warnings.catch_warnings():
+            if self.warnings:
+                # if self.warnings is set, use it to filter all the warnings
+                warnings.simplefilter(self.warnings)
+                # if the filter is 'default' or 'always', special-case the warnings from the deprecated
+                # unittest methods to show them no more than once per module, because they can be fairly
+                # noisy.  The -Wd and -Wa flags can be used to bypass this only when self.warnings is None.
+                if self.warnings in ['default', 'always']:
+                    warnings.filterwarnings('module',
+                                            category=DeprecationWarning,
+                                            message=r'Please use assert\w+ instead.')
+            start_time = time.time()
+            startTestRun = getattr(result, 'startTestRun', None)
+            if getattr(result, 'startTestRun', None) is not None:
+                startTestRun()
+            try:
+                test(result)
+            finally:
+                stopTestRun = getattr(result, 'stopTestRun', None)
+                if stopTestRun is not None:
+                    stopTestRun()
+            stop_time = time.time()
+        result.printErrors()
+
+        expectedFails = unexpectedSuccesses = skipped = 0
+        try:
+            results = map(len, (result.expectedFailures,
+                                result.unexpectedSuccesses,
+                                result.skipped))
+        except AttributeError:
+            pass
+        else:
+            expectedFails, unexpectedSuccesses, skipped = results
+
+        infos = []
+        runned = result.testsRun
+        if not result.wasSuccessful():
+            self.stream.write("FAILED")
+            failed, errored = len(result.failures), len(result.errors)
+            if failed:
+                infos.append(f"failures={failed:d}")
+            if errored:
+                infos.append(f"errors={errored:d}")
+        if skipped:
+            infos.append(f"skipped={skipped:d}")
+        if expectedFails:
+            infos.append(f"expected failures={expectedFails:d}")
+        if unexpectedSuccesses:
+            infos.append(f"unexpected successes={unexpectedSuccesses:d}")
+        if debug_print:
+            print(f"\nQuietTestRunner Time Taken: {stop_time - start_time} seconds")
+            print(f"---Result Start---\n{result}\n---Result End---")
+            print(f"---infos Start---\n{infos}\n---infos End---")
+            print(f'passed = {runned}')         # Why is this always zero?
+        return result
+
+
+class MockBlenderObject:
+    """A very simple object on which to test some properties"""
+
+    def __init__(self, name, scale=Vector([1, 1, 1])):
+        self.name = name
+        self.scale = scale
+
+
+class TestControl(unittest.TestCase):
+    """ Test the functions in the main block:
+        # has_unapplied_scale
+        # is_bad_name   """
+
+    def test_scale_application(self):
+        """Check for unapplied scale """
+        for bad in [[0, 0, 0], [1, 2, 3], [1, 1, 1.1]]:
+            self.assertEqual(
+                True, MESH_PT_MeshLintControl.has_unapplied_scale(bad),
+                "Unapplied scale: %s" % bad)
+        self.assertEqual(
+            False, MESH_PT_MeshLintControl.has_unapplied_scale([1, 1, 1]),
+            "Applied scale (1,1,1)")
+
+    def test_bad_names(self):
+        """Check a couple of good & bad names likely to be in the scene"""
+        for bad in ['Cube', 'Cube.001', 'Sphere.123']:
+            self.assertEqual(
+                True, MESH_PT_MeshLintControl.is_bad_name(bad),
+                f"Bad name: {bad}")
+        for aok in ['Whatever', 'NumbersOkToo.001']:
+            self.assertEqual(
+                False, MESH_PT_MeshLintControl.is_bad_name(aok),
+                f"OK name: {aok}")
+
+
+class TestUtilities(unittest.TestCase):
+    """ Test class for utilities:
+            # ensure_edit_mode, is_edit_mode
+            # ensure_not_edit_mode, is_edit_mode
+            # depluralize  """
+
+    def test_is_edit_mode(self):
+        """Check flipping in and out of edit mode"""
+        ensure_edit_mode()
+        self.assertEqual(True, is_edit_mode(),
+                         "Ensures edit mode then checks if in edit mode")
+        ensure_not_edit_mode()
+        self.assertEqual(False, is_edit_mode(),
+                         "Ensures not edit mode then checks if not edit mode")
+
+    def test_depluralize(self):
+        """The depluralize attempts to remove a lower case 's'
+        only if the count arg is exactly 1. This is obviously limited in generalist capabilities.
+        I'm messing around here but "Tris" does end up at "Tri" currently."""
+        self.assertEqual('foo',
+                         depluralize(count=1, string='foos'))
+        self.assertEqual('foos',
+                         depluralize(count=2, string='foos'))
+        self.assertNotEqual('FOO',
+                            depluralize(count=1, string='FOOS'))
+        self.assertNotEqual('fox',
+                            depluralize(count=1, string='foxes'), "Singular of Foxes is Foxe!")
+        self.assertNotEqual('Blueberry',
+                            depluralize(count=1, string='Blueberries'), "Singular of Blueberries is Blueberrie")
+        self.assertEqual('sheep',
+                         depluralize(count=1, string='sheep'), "Singular of Sheep is Sheep")
+
+
+class TestAnalysis(unittest.TestCase):
+    """Checks the making of the dictionary."""
+
+    def test_make_labels_dict(self):
+        """Checks that the format of the labels in the dictionary is good"""
+        self.assertEqual(
+            {
+                'Label One': {
+                    'edges': [1, 2], 'verts': [], 'faces': []},
+                'Label Two': {
+                    'edges': [], 'verts': [5], 'faces': [3]}
+            },
+            MeshLintContinuousChecker.make_labels_dict(
+                [
+                    {'lint': {'label': 'Label One'},
+                     'edges': [1, 2], 'verts': [], 'faces': []},
+                    {'lint': {'label': 'Label Two'},
+                     'edges': [], 'verts': [5], 'faces': [3]}
+                ]),
+            'Conversion of incoming analysis into label-keyed dict')
+        self.assertEqual({},
+                         MeshLintContinuousChecker.make_labels_dict(None),
+                         'Handles "None" OK.')
+
+    def test_comparison(self):
+        """ Test group to check the diff_analyses block of code
+        1) None - None = None            # constant labels
+        2) None - thing = thing          # constant labels
+        3) a(set) - b(set) = (a-b)(set)  # constant labels
+        4) A(B) - C(D) = (A-C)(B-D)      # labels and data both change """
+        self.assertEqual(
+            None,
+            MeshLintContinuousChecker.diff_analyses(
+                MeshLintAnalyzer.none_analysis(),
+                MeshLintAnalyzer.none_analysis()),
+            'Two none_analysis()s')
+        self.assertEqual(
+            'Found Tris: 4 verts',
+            MeshLintContinuousChecker.diff_analyses(
+                None,
+                [
+                    {
+                        'lint': {'label': 'Tris'},
+                        'verts': [1, 2, 3, 4],
+                        'edges': [],
+                        'faces': [],
+                    },
+                ]),
+            'When there was no previous analysis')
+        self.assertEqual(
+            'Found Tris: 2 edges, ' +
+            'Nonmanifold Elements: 4 verts, 2 faces',
+            MeshLintContinuousChecker.diff_analyses(
+                [
+                    {'lint': {'label': 'Tris'},
+                     'verts': [], 'edges': [1, 4], 'faces': [], },
+                    {'lint': {'label': 'CheckB'},
+                     'verts': [], 'edges': [2, 3], 'faces': [], },
+                    {'lint': {'label': 'Nonmanifold Elements'},
+                     'verts': [], 'edges': [], 'faces': [2, 3], },
+                ],
+                [
+                    {'lint': {'label': 'Tris'},
+                     'verts': [], 'edges': [1, 4, 5, 6], 'faces': [], },
+                    {'lint': {'label': 'CheckB'},
+                     'verts': [], 'edges': [2, 3], 'faces': [], },
+                    {'lint': {'label': 'Nonmanifold Elements'},
+                     'verts': [1, 2, 3, 4], 'edges': [], 'faces': [1, 2, 3, 5], },
+                ]),
+            'Complex comparison of analyses')
+        self.assertEqual(
+            'Found Tris: 2 verts, Ngons: 2 faces, ' +
+            'Nonmanifold Elements: 2 edges',
+            MeshLintContinuousChecker.diff_analyses(
+                [
+                    {'lint': {'label': '6+-edge Poles'},
+                     'verts': [], 'edges': [2, 3], 'faces': [], },
+                    {'lint': {'label': 'Nonmanifold Elements'},
+                     'verts': [], 'edges': [2, 3], 'faces': [], },
+                ],
+                [
+                    {'lint': {'label': 'Tris'},
+                     'verts': [55, 56], 'edges': [], 'faces': [], },
+                    {'lint': {'label': 'Ngons'},
+                     'verts': [], 'edges': [], 'faces': [5, 6], },
+                    {'lint': {'label': 'Nonmanifold Elements'},
+                     'verts': [], 'edges': [2, 3, 4, 5], 'faces': [], },
+                ]),
+            'User picked a different set of checks since last run.')
+
+
+class TestUI(unittest.TestCase):
+    """This group of tests cover the UI parts of the Extension"""
+    def test_complaints(self):
+        """Tests for the text manipulation of the GUI
+            # using build_object_criticisms
+        """
+        fff = MESH_PT_MeshLintControl.build_object_criticisms
+        self.assertEqual([], fff([], 0), 'Nothing selected')
+        self.assertEqual([],
+            fff([MockBlenderObject('lsmft')], 0),
+            'Ok name')
+        self.assertEqual(['...but "Cube" is not a great name.'],
+            fff([MockBlenderObject('Cube')], 0),
+            'Bad name, otherwise problem-free.')
+        self.assertEqual([],
+            fff([MockBlenderObject('Hassenfrass')], 12),
+            'Good name, but with problems.')
+        self.assertEqual(['...and also "Cube" is not a great name.'],
+            fff([MockBlenderObject('Cube')], 23),
+            'Bad name, and problems, too.')
+        self.assertEqual(['...but "Sphere" is not a great name.',
+                               '...and also "Cube" is not a great name.'],
+            fff([MockBlenderObject('Sphere'),
+                        MockBlenderObject('Cube')], 0),'Two bad names.')
+        scaled = MockBlenderObject('Solartech', scale=Vector([.2, 2, 1]))
+        self.assertEqual(['...but "Solartech" has an unapplied scale.'],
+            fff([scaled], 0),'Only problem is unapplied scale.')


### PR DESCRIPTION
The init has now the unittest components separated into a new file for better code maintenance. 
Use: invoke blender from the command line with the background and python args and a link to the init.py.

There is a new folder for /tests/ which has a collection of files to run the extension in headless blender.
From the tests folder use system python to call main.py.
Prerequisites: 
* The versions of Blender need to be installed - at a findable location.
* The extension will have to be sym-linked to the installation extensions folder, this is in .config/blender/... on linux.

TODO in another PR will be to run the unit test as part of the Blender version regression suite.