### PR TITLE
Make it work for Blender 4.4 and 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ---
+### Version 0.1.3 for Blender 4.2 onwards
+
+New Features:
+* None. Works with Blender 4.2, 4.3, 4.4 & 4.5
+
+Fixes:
+* Broken for Blender 4.4 & 4.5 - they changed a python API. #9
+* Prevent double registration from unittest.
+
+Known Issues:
+* Incorrect lint selection with multiple objects #7
+* Deselection of Lint-free objects does not happen if all are lint free.
+
+---
 ### Version 0.1.2 for Blender 4.2 and 4.3
 
 New Features:

--- a/__init__.py
+++ b/__init__.py
@@ -68,9 +68,8 @@ class MeshLintAnalyzer:
     """The main brain of the application: Finds the problems and defines the checks"""
     CHECKS = []
 
-    def __init__(self):
-    # def __init__(self, *args, **kwargs):
-        #super().__init__(*args, **kwargs)      # For blender 4.4 onwards
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)      # For blender 4.4 onwards
         ensure_edit_mode()
         self.obj = bpy.context.active_object
         self.b = bmesh.from_edit_mesh(self.obj.data)
@@ -448,9 +447,8 @@ def activate(obj):
 
 class MeshLintObjectLooper:
     """Routines for examining the scene objects"""
-    def __init__(self):
-    # def __init__(self, *args, **kwargs):
-        # super().__init__(*args, **kwargs)         # For blender 4.4 onwards
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)         # For blender 4.4 onwards
         self.original_active = bpy.context.active_object
         self.troubled_meshes = []
 
@@ -742,8 +740,9 @@ classes = (
 
 def register():
     """Register the classes in Blender"""
-    for cls in classes:
-        bpy.utils.register_class(cls)
+    if not hasattr(bpy.types, 'MESH_PT_MeshLintControl'):  # Prevent double registration from unittest
+        for cls in classes:
+            bpy.utils.register_class(cls)
 
 def unregister():
     """Un-Register the classes in Blender & also make sure continuous to stopped"""
@@ -751,7 +750,10 @@ def unregister():
         if handy.__name__ == 'meshlint_gbl_continuous_check':
             bpy.app.handlers.depsgraph_update_post.remove(handy)
     for cls in reversed(classes):
-        bpy.utils.unregister_class(cls)
+        try:
+            bpy.utils.unregister_class(cls)
+        except:
+            pass
 
 if __name__ == "__main__":
     register()

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -6,7 +6,7 @@ schema_version = "1.0.0"
 
 id = "MeshLint"
 name = "MeshLint"
-version = "0.1.2"
+version = "0.1.3"
 tagline = "MeshLint is like spell-checking for your Meshes"
 # "description": "Check objects for: Tris / Ngons / Nonmanifoldness / etc"
 # "location": "Object Data properties > MeshLint"

--- a/tests/check_installed.py
+++ b/tests/check_installed.py
@@ -13,7 +13,7 @@ import bmesh
 import bpy
 
 EXTENSION_NAME = "MeshLint"     # Case matters
-MIN_VERSION = (0,1,2)
+MIN_VERSION = (0,1,3)
 
 
 def test_loaded() -> None:


### PR DESCRIPTION
Addresses the breaking API change in Blender 4.4
https://developer.blender.org/docs/release_notes/4.4/python_api/#subclassing-blender-types
Pass on the generic positional and keyword arguments.